### PR TITLE
Add a "data" element to the IRecord interface for storing the JSON Record data

### DIFF
--- a/src/umbral.ts
+++ b/src/umbral.ts
@@ -5,6 +5,7 @@ import uuidv4 = require('uuid/v4');
 export interface IRecord {
   readonly perpId: string;
   readonly userId: string;
+  readonly data: string;
 }
 
 /**


### PR DESCRIPTION
Currently we are storing the record data in perpID, which works fine. I feel like this change is very generic. Let me know if you need tests for it.